### PR TITLE
Convert getbible.net output into a Python dict

### DIFF
--- a/BiblePassageAsDict.py
+++ b/BiblePassageAsDict.py
@@ -1,0 +1,9 @@
+import json, requests
+
+def passage_as_dict(ref, version):
+    '''getbible.net does not valid json so we convert (content); to [content]'''
+    fmt = 'https://getbible.net/json?p={}&v={}'
+    url = fmt.format(ref.replace(' ', '%20'), version)
+    return json.loads('[{}]'.format(requests.get(url).text[1:-2]))
+
+print(passage_as_dict('Luke 3:1', 'nasb'))


### PR DESCRIPTION
getbible.net does not return valid json so we need to convert (content); --> [content] to obtain valid json.  We can then run json.loads() on the result to get a Python dictionary.  Having a dict should greatly simplify both cleanup() and printing.
