### PR TITLE
Removes the idiosyncrasies of getbible.net dicts

### DIFF
--- a/BiblePassageAsDict.py
+++ b/BiblePassageAsDict.py
@@ -3,16 +3,39 @@
 
 import json, requests
 
+
+def convert_dict_chapter(srce):
+    '''return three dicts embedded inside each other: book, chapter, verse'''
+    # print(json.dumps(srce, indent=4, sort_keys=True))
+    return {srce['book_name']: {int(srce['chapter_nr']): {int(verse):
+        verse_contents['verse'] for verse, verse_contents
+            in srce['chapter'].iteritems()}}}
+
+
+def convert_dict(srce):
+    '''return three dicts embedded inside each other: book, chapter, verse'''
+    # print(json.dumps(srce, indent=4, sort_keys=True))
+    if srce['type'] == 'chapter':
+        return convert_dict_chapter(srce)
+    elif srce['type'] == 'verse':
+        return convert_dict_chapter(srce['book'][0])
+    return {srce['book_name']: {int(chapter): {int(verse): verse_contents['verse']
+            for verse, verse_contents in chapter_contents['chapter'].iteritems()}
+                for chapter, chapter_contents in srce['book'].iteritems()}}
+
+
 def passage_as_dict(ref, version='nasb'):
     '''getbible.net does not valid json so we convert (content); to [content]'''
     fmt = 'https://getbible.net/json?p={}&v={}'
     url = fmt.format(ref.replace(' ', '%20'), version)
-    return json.loads('[{}]'.format(requests.get(url).text[1:-2]))
+    return convert_dict(json.loads(requests.get(url).text[1:-2]))
+
 
 def passages_as_dicts(ref, version='nasb'):
     return [passage_as_dict(p.strip(), version)
             for p in ref.split(';') if p.strip()]
 
-# Matthew is 'type': 'book', Mark is 'type': 'chapter', Luke and John are 'type': 'verse'
-passages = passages_as_dicts('Matthew;Mark 1;Luke 1:1;John 1:1-3')
+
+# Matthew is 'type': 'book', Mark is 'chapter', Luke and John are 'verse'
+passages = passages_as_dicts('Matthew;Mark 2;Luke 2:1;John 2:8-12')
 print(json.dumps(passages, indent=4, sort_keys=True))

--- a/BiblePassageAsDict.py
+++ b/BiblePassageAsDict.py
@@ -27,13 +27,12 @@ def convert_dict(srce):
 def passage_as_dict(ref, version='nasb'):
     '''getbible.net does not valid json so we convert (content); to [content]'''
     fmt = 'https://getbible.net/json?p={}&v={}'
-    url = fmt.format(ref.replace(' ', '%20'), version)
+    url = fmt.format(ref.strip().replace(' ', '%20'), version.strip())
     return convert_dict(json.loads(requests.get(url).text[1:-2]))
 
 
 def passages_as_dicts(ref, version='nasb'):
-    return [passage_as_dict(p.strip(), version)
-            for p in ref.split(';') if p.strip()]
+    return [passage_as_dict(p, version) for p in ref.split(';') if p.strip()]
 
 
 # Matthew is 'type': 'book', Mark is 'chapter', Luke and John are 'verse'


### PR DESCRIPTION
This update took a while to get just right but should help a lot!   The getbible.net API returns subtly different dicts for books, chapters, and verses with extra dicts in between to make it even more confusing.  All of this overhead can cause a lot of frustration.

convert_dict() will return flattened _verses dicts_ embedded in _chapter dicts_ embedded in a single _book dict_.  The resulting dicts are identical across API queries for books, chapters, and verses.  They pack data more tightly but are much easier to parse.
